### PR TITLE
prevent calling function on undefined fileInstance

### DIFF
--- a/src/components/Clip/index.js
+++ b/src/components/Clip/index.js
@@ -258,6 +258,7 @@ component.methods.addedFile = function (file) {
  */
 component.methods.removedFile = function ({ blobId }) {
   const fileInstance = this.getFile(blobId)
+  if(!fileInstance.updateStatus) return
   fileInstance.updateStatus('removed')
   this.onRemovedFile(fileInstance)
 }
@@ -283,6 +284,7 @@ component.methods.sending = function ({ blobId }, xhr, formData) {
  */
 component.methods.complete = function ({ blobId, status, xhr = {} }) {
   const fileInstance = this.getFile(blobId)
+  if(!fileInstance.updateStatus) return
   fileInstance.updateStatus(status)
   fileInstance.updateXhrResponse({
     response: xhr.response,
@@ -302,6 +304,7 @@ component.methods.complete = function ({ blobId, status, xhr = {} }) {
  */
 component.methods.error = function ({ blobId, status }, errorMessage) {
   const fileInstance = this.getFile(blobId)
+  if(!fileInstance.updateStatus) return
   fileInstance.updateStatus(status)
   fileInstance.updateErrorMessage(errorMessage)
 }
@@ -315,6 +318,7 @@ component.methods.error = function ({ blobId, status }, errorMessage) {
  */
 component.methods.uploadProgress = function ({ blobId }, progress, bytesSent) {
   const fileInstance = this.getFile(blobId)
+  if(!fileInstance.updateProgress) return
   fileInstance.updateProgress(progress)
   fileInstance.updateBytesSent(bytesSent)
 }
@@ -327,6 +331,7 @@ component.methods.uploadProgress = function ({ blobId }, progress, bytesSent) {
  */
 component.methods.thumbnail = function ({ blobId }, dataUrl) {
   const fileInstance = this.getFile(blobId)
+  if(!fileInstance.updateDataUrl) return
   fileInstance.updateDataUrl(dataUrl)
 }
 


### PR DESCRIPTION
`getFile()` could potentially return an empty object. Calling e.g. `updateStatus` on that object will throw an error.
I observed this behavior on Firefox. E.g. the `thumbnail`event-handler was invoked after the `this.files` was cleared. It resulted in:

```
TypeError: this.getFile(...).updateDataUrl is not a function
  at this(~/vue-clip/dist/vue-clip.js:992:0)
  at fn(~/vue/dist/vue.esm.js:163:0)
  at callback(~/vue-clip/dist/vue-clip.js:1836:0)
  at _this(~/vue-clip/dist/vue-clip.js:2902:0)
```

Firefox 54 and 52
vue-clip 1.0.0
vue 2.3.3